### PR TITLE
Fix-up install

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,12 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --record=record.txt
+  script: python setup.py install
 
 requirements:
   build:
     - python
+    - setuptools
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ test:
 about:
   home: https://github.com/mwilliamson/locket.py
   license: BSD 2-Clause
+  license_file: LICENSE
   summary: File-based locks for Python for Linux and Windows
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: fe870949c513d8f7079ba352463833ca
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install
 
 requirements:


### PR DESCRIPTION
- Drop unneeded `setup.py` arguments.
- Package the license file.
- Bump build number to `1`.
